### PR TITLE
mrbwrite プロトコルのESP32互換対応

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -193,10 +193,9 @@ int mrbwrite_cmd_mode() {
   }
   // ファイル消去コマンドの処理
   if (cmd == MRBWRITE_CLEAR) {
-    printf("+OK\r\n");
     vfs_remove("master.mrbc");
     vfs_remove("slave.mrbc");
-    printf("+DONE\r\n");
+    printf("+OK\r\n");
   }
 
   // ヘルプコマンドの処理
@@ -219,7 +218,6 @@ int mrbwrite_cmd_mode() {
   }
   // プログラム表示コマンドの処理
   if (cmd == MRBWRITE_SHOWPROG) {
-    printf("+OK\r\n");
     if (vfs_stat_size("master.mrbc", &buffer_size) >= 0 && buffer_size > 0) {
       buffer = calloc(buffer_size, sizeof(uint8_t));
       if (buffer != NULL && vfs_read("master.mrbc", buffer, buffer_size) > 0) {

--- a/main/vfs.c
+++ b/main/vfs.c
@@ -209,7 +209,7 @@ int vfs_unmount() {
 /** @brief ファイルのCRC8チェックサム計算
 
   指定されたファイルの内容からCRC8チェックサムを計算する．
-  生成多項式は0x07を使用し，初期値は0xFFとする．
+  生成多項式は0x31を使用し，初期値は0xFFとする．
 
   @param filename 対象ファイル名
   @param _crc CRC8値を格納する変数のポインタ（NULLの場合は無視される）
@@ -218,7 +218,7 @@ int vfs_unmount() {
 int vfs_crc8(const char* filename, uint8_t* _crc) {
   // CRC8初期値と生成多項式の設定
   uint8_t crc = 0xFF;
-  const uint8_t poly = 0x07;
+  const uint8_t poly = 0x31;
 
   // ファイルの内容を動的メモリで読み込み
   uint8_t *buffer = NULL;


### PR DESCRIPTION
コマンドにESP32版（[gfd-dennou-club/mrubyc-esp32](https://github.com/gfd-dennou-club/mrubyc-esp32)）との非互換があったため修正しました。

* clear : レスポンスでDONEを返さず、完了時にOKを返します。
* showprog : レスポンスではOKを返さず、完了時にDONEを返します。
* verify : CRC8チェックサム計算時の生成多項式をESP32に合わせて0x31とします。