### PR TITLE
Pico 2 (RP2350) のサポート

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,9 @@ cmake_minimum_required(VERSION 3.16)
 
 # picotoolのインストール先（ない場合はダウンロード）
 set(PICOTOOL_FETCH_FROM_GIT_PATH ${CMAKE_SOURCE_DIR}/components/picotool CACHE PATH "")
+
 # pico-sdkのビルド設定
 set(PICO_SDK_PATH ${CMAKE_SOURCE_DIR}/components/pico-sdk CACHE STRING "")
-set(PICO_PLATFORM rp2040 CACHE STRING "")
-set(PICO_BOARD pico CACHE STRING "")
-set(PICO_COMPILER pico_arm_cortex_m0plus_gcc CACHE STRING "")
 
 # Pico SDKの導入およびプロジェクト設定
 include(components/pico-sdk/pico_sdk_init.cmake)
@@ -24,8 +22,11 @@ pico_sdk_init()
 # mruby/cのコンパイルオプションの設定
 add_compile_options(-DMRBC_NO_TIMER -DMRBC_USE_HAL_RP2040 -DMRBC_REQUIRE_32BIT_ALIGNMENT -DMAX_REGS_SIZE=256 -DMAX_SYMBOLS_COUNT=500)
 
+# mainターゲットの作成
+add_executable(main)
+
 # mainの構成ファイル
-add_executable(main
+target_sources(main PUBLIC
   main/main.c
   main/mrbc_pico_gpio.c
   main/mrbc_pico_pwm.c

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,40 @@
 #  MakefileによるCMakeビルド手順の簡略化
 #
 #  CMakeのビルドプロセスを簡略化するためのラッパー．
-#  プロジェクトのルートディレクトリで `make` を実行すると，ビルドディレクトリの作成，CMakeの実行，コンパイルが自動的に行われる．
+#  複数のボード（Pico、Pico2など）に対応するため `make` のみを実行すると選択メニューが表示される．
+#
+#  `make pico` など直接ボードを指定すると，そのボード用のファームウェアのみビルドされる．
+#  `make all` の場合は全てのボード用のファームウェアがビルドされる．
 # ====================================================================
 
 # Makefileで定義されるコマンド一覧（非ファイル）
-.PHONY: all clean configure mrbc help
+.PHONY: default all clean mrbc help pico pico2
 
-# make コマンドのデフォルトで実行されるターゲット指定
-.DEFAULT_GOAL := all
+# make コマンドのデフォルトターゲット
+.DEFAULT_GOAL := default
 
-# プロジェクトのビルド
-all: build/Makefile
-	@make --no-print-directory -C build
+# ボード選択メニュー（選択後に `make <board>` が呼び出される）
+default:
+	@echo -n "1) pico  2) pico2 : "; \
+	read choice; \
+	case $$choice in \
+		1) $(MAKE) pico;; \
+		2) $(MAKE) pico2;; \
+		*) echo "Invalid selection" >&2; exit 1;; \
+	esac
+
+# 全ボードビルド
+all: pico pico2
+
+# ボードターゲット（CMake設定済みのビルドディレクトリに依存）
+pico pico2: %: build/%/Makefile
+	@$(MAKE) --no-print-directory -C build/$*
 
 # CMakeのビルド設定ファイル（Makefile）の生成ルール
 #
 # CMakeLists.txt更新時のみ実行される．
-build/Makefile: CMakeLists.txt
-	@cmake -S . -B build
+build/%/Makefile: CMakeLists.txt
+	@cmake -S . -B build/$* -DPICO_BOARD=$*
 
 # ビルド成果物の削除
 clean:
@@ -34,6 +50,9 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Available targets:"
-	@echo "  all         (Default) Configure and build the project."
+	@echo "  (default)   Select board interactively."
+	@echo "  all         Build for all boards."
+	@echo "  pico        Build for Pico."
+	@echo "  pico2       Build for Pico 2."
 	@echo "  clean       Remove all build artifacts."
 	@echo "  help        Show this help message."

--- a/mrblib/adc.rb
+++ b/mrblib/adc.rb
@@ -17,8 +17,8 @@ class ADC
 
   # ADCインスタンスの初期化
   #
-  # @param pin [Integer] ADCピン番号（GPIO26-29: RP2040，GPIO40-47: RP2350）
-  # @param params [Hash] ADC設定パラメータ（将来拡張用）
+  # @param pin [Integer] ADCピン番号
+  # @param params [Hash] ADC設定パラメータ
   # @raise [ArgumentError] ピンが無効な場合
   #
   # @example
@@ -31,8 +31,6 @@ class ADC
 
     @pin = pin
 
-    # RP2040: GPIO26-29 -> チャンネル0-3
-    # [TODO] RP2350: GPIO40-47 -> チャンネル0-7
     @channel = case @pin
     when 26 then 0
     when 27 then 1

--- a/mrblib/i2c.rb
+++ b/mrblib/i2c.rb
@@ -16,7 +16,7 @@
 #   i2c.write(0x45, 0x30, 0xa2)
 class I2C
   # GPIOの機能定数（I2C用）
-  GPIO_FUNC_I2C = 3 # C: enum gpio_function_rp2040 { GPIO_FUNC_I2C = 3 }
+  GPIO_FUNC_I2C = 3 # C: enum gpio_function_rp2040, gpio_function_rp2350 { GPIO_FUNC_I2C = 3 }
 
   attr_reader :unit, :frequency, :scl_pin, :sda_pin
 
@@ -25,12 +25,16 @@ class I2C
   # @param id [Integer] 物理ユニット番号（0または1，デフォルト: 0）
   # @param frequency [Integer] I2C周波数（Hz単位，デフォルト: 100kHz）
   # @param freq [Integer] frequencyのエイリアス
-  # @param scl_pin [Integer] SCLピン番号（デフォルト: RP2040では5）
-  # @param sda_pin [Integer] SDAピン番号（デフォルト: RP2040では4）
+  # @param scl_pin [Integer] SCLピン番号（デフォルト: 5）
+  # @param sda_pin [Integer] SDAピン番号（デフォルト: 4）
   #
   # RP2040 I2C対応ピン:
-  #   I2C0: SDA=0,4,8,12,16,20  SCL=1,5,9,13,17,21
-  #   I2C1: SDA=2,6,10,14,18,26 SCL=3,7,11,15,19,27
+  #   I2C0: SDA=0,4,8,12,16,20  | SCL=1,5,9,13,17,21
+  #   I2C1: SDA=2,6,10,14,18,26 | SCL=3,7,11,15,19,27
+  #
+  # RP2350 I2C対応ピン:
+  #   I2C0: SDA=0,4,8,12,16,20,24,28 | SCL=1,5,9,13,17,21,25,29
+  #   I2C1: SDA=2,6,10,14,18,22,26   | SCL=3,7,11,15,19,23,27
   #
   # @example
   #   i2c = I2C.new
@@ -49,14 +53,12 @@ class I2C
     # @see https://picodocs.pinout.xyz/group__hardware__i2c.html
     @frequency = (freq || frequency).to_i.clamp(1, 1_000_000)
 
-    # デフォルトピンの設定
-    # RP2040: I2C0 => GP4(SDA), GP5(SCL), I2C1 => GP6(SDA), GP7(SCL)
-    # [TODO] RP2350: I2C0 => GP8(SDA), GP9(SCL), I2C1 => GP10(SDA), GP11(SCL)
+    # デフォルトはボードに合わせる
     if @unit == 0
-      @scl_pin = scl_pin || 5  # RP2040のデフォルト
+      @scl_pin = scl_pin || 5
       @sda_pin = sda_pin || 4
     else
-      @scl_pin = scl_pin || 7  # RP2040のデフォルト
+      @scl_pin = scl_pin || 7
       @sda_pin = sda_pin || 6
     end
 


### PR DESCRIPTION
既存のPico（RP2040 ）に加えて、Pico2（RP2350）対応を追加しました。

RubyのAPIおよびC拡張には変更がありませんが、ファームウェアの生成手順・生成先に非互換があります。

**１．現行**

```sh
make # => build/main.uf2 に出力
```

**２．本PRでの変更**

`pico` `pico2` を切り替え可能になるため、ビルド成果物の出力先が衝突しないよう `build/pico/main.uf2` または `build/pico2/main.uf2` としております。

```sh
#
# 1. make （引数なし）コマンドの場合
#
make # => 引数なしの場合は下記メニューから選択

    # 1) pico  2) pico2 : 1 ※ 「1」を選択した場合
    # make[1]: Entering directory '/path/to/mrubyc-pico'

#
# 2. make コマンドに引数を指定
#

# 2.1 pico（現行）
make pico # => build/pico/main.uf2 に出力

# 2.2 pico2（追加）
make pico2 # => build/pico2/main.uf2 に出力

# 2.3 全ボード
make all # => 上記２つを実行
```

お手数ですがご確認いただけますと幸いにございます。