### PR TITLE
ブレーク信号の受信による再起動のサポート

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(main
   main/mrbc_pico_adc.c
   main/mrbc_pico_i2c.c
   main/mrbc_pico_bootsel.c
+  main/mrbc_pico_break.c
   main/bootsel.c
   main/hal.c
   main/mrbwrite.c

--- a/main/main.c
+++ b/main/main.c
@@ -108,7 +108,7 @@ int main() {
   mrbc_pico_i2c_gem_init(0);
   mrbc_pico_uart_gem_init(0);
   mrbc_pico_bootsel_gem_init(0);
-  mrbc_pico_break_init(0);
+  mrbc_pico_break_gem_init(0);
 
   // Ruby 側のクラス・メソッド定義
   extern const uint8_t myclass_bytecode[];

--- a/main/main.c
+++ b/main/main.c
@@ -27,6 +27,7 @@ int mrbwrite_cmd_mode();
 #include "mrbc_pico_pwm.h"
 #include "mrbc_pico_adc.h"
 #include "mrbc_pico_i2c.h"
+#include "mrbc_pico_break.h"
 
 //*********************************************
 // ENABLE LIBRARY written by C (Utilities)
@@ -105,6 +106,7 @@ int main() {
   mrbc_pico_pwm_gem_init(0);
   mrbc_pico_adc_gem_init(0);
   mrbc_pico_i2c_gem_init(0);
+  mrbc_pico_break_init(0);
 
   // Ruby 側のクラス・メソッド定義
   extern const uint8_t myclass_bytecode[];

--- a/main/mrbc_pico_break.c
+++ b/main/mrbc_pico_break.c
@@ -33,7 +33,7 @@ void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
 
   @param vm mruby/c VMインスタンス（未使用）
 */
-void mrbc_pico_break_init(struct VM* vm) {
+void mrbc_pico_break_gem_init(struct VM* vm) {
   (void)vm;
 
   // 有効化（0 → 1）

--- a/main/mrbc_pico_break.c
+++ b/main/mrbc_pico_break.c
@@ -1,0 +1,41 @@
+/*! @file
+  @brief Break信号によるリブート機能
+
+  USB CDCのBreak信号を受信した際に，ウォッチドッグタイマーを使ってソフトリセットする．
+*/
+
+#include "mrbc_pico_break.h"
+#include "tusb.h"
+#include "hardware/watchdog.h"
+
+static int mode = 0;  // 0: 未初期化，1: 有効，2: 再起動実行済
+
+/*! @brief TinyUSBのBreak信号受信コールバック
+
+  USB CDCでBreak信号を受信した際にTinyUSBから呼び出される．
+  （TinyUSBのweakシンボルを上書きしてコールバック登録）
+
+  ウォッチドッグタイマを使って100ms後に再起動する．
+
+  @param itf CDCインターフェース番号（未使用）
+  @param duration_ms Break信号の持続時間（未使用）
+*/
+void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
+  (void)itf;
+  (void)duration_ms;
+  if (mode == 1) {
+    mode = 2;
+    watchdog_reboot(0, 0, 100);
+  }
+}
+
+/*! @brief Break信号によるリブート機能の初期化
+
+  @param vm mruby/c VMインスタンス（未使用）
+*/
+void mrbc_pico_break_init(struct VM* vm) {
+  (void)vm;
+
+  // 有効化（0 → 1）
+  mode = 1;
+}

--- a/main/mrbc_pico_break.h
+++ b/main/mrbc_pico_break.h
@@ -1,0 +1,9 @@
+#ifndef MRBC_PICO_BREAK_H
+#define MRBC_PICO_BREAK_H
+
+struct VM; // #include "mrubyc.h"
+
+// Break信号によるリブート機能を初期化する
+void mrbc_pico_break_init(struct VM* vm);
+
+#endif // MRBC_PICO_BREAK_H

--- a/main/mrbc_pico_break.h
+++ b/main/mrbc_pico_break.h
@@ -4,6 +4,6 @@
 struct VM; // #include "mrubyc.h"
 
 // Break信号によるリブート機能を初期化する
-void mrbc_pico_break_init(struct VM* vm);
+void mrbc_pico_break_gem_init(struct VM* vm);
 
 #endif // MRBC_PICO_BREAK_H


### PR DESCRIPTION
## 概要

Kaniwriterではボードの起動時にコマンド受付モードに入ることを想定しています。
ESP32開発ボードではENボタンにより簡単に再起動できるのですが、Raspberry Pi Picoには物理ボタンがなく毎回ケーブルの抜き差しが必要でした。

本件では、UART（USB経由）のBreak信号の受信時にソフトリセットを行う実装を追加しました。

## その他

なお、Break信号を送る側の参考実装は下記です。
ブラウザの場合はWeb Serial API（`navigator.serial.requestPort()`で取得するUSBポート）から `setSignals({ break: true|false })` で送信・停止できるようになります。
ボードの再起動により切断されるため、簡単に例外ハンドルだけしています。

https://github.com/matsudai/kaniburner/blob/affc5872537975ef4107ae0c6918a33e5dea57de/kaniburner-browser/app.js#L697-L713