### PR TITLE
mrubyをOSではなくこのリポジトリの依存として追加

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = components/picotool
 	url = https://github.com/raspberrypi/picotool.git
 	ignore = dirty
+[submodule "components/mruby"]
+	path = components/mruby
+	url = https://github.com/mruby/mruby.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,13 @@ target_include_directories(main PUBLIC
   components/littlefs
 )
 
+# mrubyコンパイラのパス
+set(MRBC ${CMAKE_SOURCE_DIR}/components/mruby/build/host/bin/mrbc)
+
 # mruby/c組み込みのRubyクラスのコンパイル（出力先: components/mrubyc/src/mrblib.c）
 add_dependencies(main mrubyc)
 add_custom_target(mrubyc
-  COMMAND make distclean all
+  COMMAND make distclean all MRBC=${MRBC}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/components/mrubyc/mrblib
 )
 
@@ -91,7 +94,7 @@ add_custom_target(mrubyc
 file(GLOB MRBLIB_RUBY_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/mrblib/*.rb")
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mrblib.c
-  COMMAND mrbc -B myclass_bytecode --remove-lv -o ${CMAKE_CURRENT_BINARY_DIR}/mrblib.c ${MRBLIB_RUBY_SOURCES}
+  COMMAND ${MRBC} -B myclass_bytecode --remove-lv -o ${CMAKE_CURRENT_BINARY_DIR}/mrblib.c ${MRBLIB_RUBY_SOURCES}
   DEPENDS ${MRBLIB_RUBY_SOURCES}
 )
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # ====================================================================
 
 # Makefileで定義されるコマンド一覧（非ファイル）
-.PHONY: default all clean mrbc help pico pico2
+.PHONY: default all clean help pico pico2 setup
 
 # make コマンドのデフォルトターゲット
 .DEFAULT_GOAL := default
@@ -37,13 +37,15 @@ pico pico2: %: build/%/Makefile
 build/%/Makefile: CMakeLists.txt
 	@cmake -S . -B build/$* -DPICO_BOARD=$*
 
+# ビルドツールのセットアップ
+#
+# mrubyコンパイラ（mrbc）をビルドする．
+setup:
+	@$(MAKE) --no-print-directory -C components/mruby
+
 # ビルド成果物の削除
 clean:
 	@rm -rf build/*
-
-mrbc:
-	@mkdir -p build
-	@mrbc -o build/master.mrbc src/master.rb
 
 # 利用可能なコマンドの表示
 help:
@@ -54,5 +56,6 @@ help:
 	@echo "  all         Build for all boards."
 	@echo "  pico        Build for Pico."
 	@echo "  pico2       Build for Pico 2."
+	@echo "  setup       Build tools (run once after clone)."
 	@echo "  clean       Remove all build artifacts."
 	@echo "  help        Show this help message."


### PR DESCRIPTION
## 概要

ファームウェアのビルドにmrubyが必要ですが、本リポジトリとは別にセットアップする必要があります。

今後リリースビルドをGitHub Actionsで生成するにあたり、ビルド環境にも同じ環境をセットアップすることになります。
しかしローカルとの環境差異によってはリリース時にエラーになるため、mrubyリポジトリを依存に追加してリスク軽減します。

また、Makefileに`mrbc`ターゲットがありましたが、使わない（作成時にテスト用に作ったものが入ったままでした）ため削除いたしました。

## 機能

`make setup` にてmrubyをビルドします。

ファームウェアのビルドまでの手順の変更：

```diff
  git clone --recurse-submodules https://github.com/matsudai/mrubyc-pico.git
  cd mrubyc-pico
+ make setup   # mrbcのビルド（初回のみ）
  make pico    # Pico用ビルド
```