### PR TITLE
GitHubのタグ付与時にリリースビルド（ファームウェア）を生成する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y cmake gcc-arm-none-eabi ruby
+
+      - name: Setup
+        run: make setup
+
+      - name: Build
+        run: make all
+
+      - name: Rename UF2
+        run: |
+          TAG=${GITHUB_REF_NAME}
+          cp build/pico/main.uf2 "PICO-${TAG}.uf2"
+          cp build/pico2/main.uf2 "PICO2-${TAG}.uf2"
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: PICO*.uf2


### PR DESCRIPTION
**★ 本件は https://github.com/gfd-dennou-club/mrubyc-pico/pull/11 に依存します（左記マージ後にマージ可能です）。**

## 概要

GitHubにGitタグを付与した際に、GitHubのReleaseを作成します。
これには添付ファイルとして `PICO-0.0.0.uf2`、 `PICO2-<tag>.uf2` が含まれます。
（前者はRaspberry Pi Pico、後者がPico2用のファームウェアで、`<tag>`はタグ名に置き換えられます）

## 利用方法

ローカルのリポジトリにてタグをつける方法：

```sh
# リリース対象を確認する
git checkout <タグをつけるブランチ>
git pull

# タグを付与する
git tag 0.0.0 # 任意のタグ名

# タグをGitHubにプッシュする
git push origin 0.0.0 # タグ名は上記に合わせる

# => プッシュ後、GitHubの「Actions」タブにてビルドが開始されます
# => 成功すると https://github.com/gfd-dennou-club/mrubyc-pico/releases にリリースが作成されます
```

## 詳細

本プルリクエストにはGitHub Action用のワークフローファイルが含まれます。
ここでは次のことを行います。
1. 本リポジトリおよびsubmoduleを取得します
2. aptパッケージをインストールします（cmakeとARM向けGCC）
3. `make setup`によりmrbcなどを準備します
4. `make all`により全ボード（Pico/Pico2）向けのファームウェアを生成します
5. いずれも`main.uf2`というファイル名のため`PICO-<tag>.uf2`などにリネームします
6. これらのファイルを含むGitHubのリリースを作成します