### PR TITLE
リリースビルドの生成方法の変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*.*.*"
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
現行はタグ付与時にトリガされ、GitHubリリースを作成していました。
しかしタグ付与はGitHub UIから行えず非効率なため、GitHubリリースの作成時にビルド→そのリリースに添付するようにします。