### PR TITLE
mrbwrite 1.3 （予定）への対応

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -73,7 +73,7 @@ int main() {
   // b. BOOTSELボタンが押された場合は実行モードに入る．
   printf("Kani-Board, Please push Enter key to mrbwite mode\r\n");
   while (!bootsel_get()) {
-    int cmd = mrbwrite_get_cmd(10 * 1000, NULL); // 10ミリ秒のタイムアウト
+    int cmd = mrbwrite_get_cmd(10 * 1000, NULL, NULL); // 10ミリ秒のタイムアウト
     if (cmd == MRBWRITE_COMMAND_MODE) {
       printf("+OK mruby/c\r\n");
       while (mrbwrite_cmd_mode());
@@ -87,13 +87,39 @@ int main() {
   //************************************
   // Rubyコード読み込み
   //************************************
-  uint8_t *master_bytecode = NULL;
-  uint32_t master_size = 0;
-  if (vfs_stat_size("master.mrbc", &master_size) >= 0 && master_size > 0) {
-    master_bytecode = calloc(master_size, sizeof(uint8_t));
-    if (master_bytecode != NULL) {
-      vfs_read("master.mrbc", master_bytecode, master_size);
+  char filename[16];
+  uint32_t size = 0;
+
+  // ライブラリバイトコードの読み込み
+  uint32_t lib_count = 0;
+  uint8_t **lib_bytecode = NULL;
+  while (1) {
+    snprintf(filename, sizeof(filename), "lib_%02d.mrbc", lib_count + 1);
+    if (vfs_stat_size(filename, &size) < 0 || size == 0) {
+      break;
     }
+    lib_bytecode = realloc(lib_bytecode, (lib_count + 1) * sizeof(uint8_t *));
+    lib_bytecode[lib_count] = calloc(size, sizeof(uint8_t));
+    if (lib_bytecode[lib_count] != NULL) {
+      vfs_read(filename, lib_bytecode[lib_count], size);
+    }
+    lib_count++;
+  }
+
+  // タスクバイトコードの読み込み
+  uint32_t task_count = 0;
+  uint8_t **task_bytecode = NULL;
+  while (1) {
+    snprintf(filename, sizeof(filename), "task_%02d.mrbc", task_count + 1);
+    if (vfs_stat_size(filename, &size) < 0 || size == 0) {
+      break;
+    }
+    task_bytecode = realloc(task_bytecode, (task_count + 1) * sizeof(uint8_t *));
+    task_bytecode[task_count] = calloc(size, sizeof(uint8_t));
+    if (task_bytecode[task_count] != NULL) {
+      vfs_read(filename, task_bytecode[task_count], size);
+    }
+    task_count++;
   }
 
   //************************************
@@ -122,17 +148,36 @@ int main() {
   extern const uint8_t myclass_bytecode[];
   mrbc_run_mrblib(myclass_bytecode);
 
+  // ユーザ独自のライブラリのクラス・メソッド定義
+  for (uint32_t i = 0; i < lib_count; i++) {
+    if (lib_bytecode[i] != NULL) {
+      mrbc_run_mrblib(lib_bytecode[i]);
+    }
+  }
+
   //***************************************
   // Ruby 実行
   //***************************************
-  if (master_bytecode != NULL) {
-    mrbc_create_task(master_bytecode, 0);
+  if (task_count > 0) {
+    for (uint32_t i = 0; i < task_count; i++) {
+      if (task_bytecode[i] != NULL) {
+        mrbc_create_task(task_bytecode[i], 0);
+      }
+    }
     mrbc_run();
-    free(master_bytecode);
-    master_bytecode = NULL;
   } else {
-    printf("Not master.mrbc exists.\r\n");
+    printf("Not task exists.\r\n");
   }
+
+  // バイトコードの解放
+  for (uint32_t i = 0; i < task_count; i++) {
+    free(task_bytecode[i]);
+  }
+  free(task_bytecode);
+  for (uint32_t i = 0; i < lib_count; i++) {
+    free(lib_bytecode[i]);
+  }
+  free(lib_bytecode);
 
   return 0;
 }
@@ -152,8 +197,9 @@ int mrbwrite_cmd_mode() {
   // writeコマンドで使用するバッファ
   uint32_t buffer_size = 0;
   uint8_t *buffer = NULL;
+  int32_t crc = -1;
   // バッファの初期化とコマンド入力の受付
-  int cmd = mrbwrite_get_cmd((uint32_t)3600 * 1000 * 1000, &buffer_size); // 1時間のタイムアウト
+  int cmd = mrbwrite_get_cmd((uint32_t)3600 * 1000 * 1000, &buffer_size, &crc); // 1時間のタイムアウト
 
   // コマンドエラーでは処理継続
   if (cmd == MRBWRITE_ILLEGAL) {
@@ -181,6 +227,16 @@ int mrbwrite_cmd_mode() {
   }
   // バイトコード書き込みコマンドの処理
   if (cmd == MRBWRITE_WRITE) {
+    // 書き込み先の決定
+    char filename[16];
+    uint32_t size = 0;
+    for (int i = 1; ; i++) {
+      snprintf(filename, sizeof(filename), "task_%02d.mrbc", i);
+      if (vfs_stat_size(filename, &size) < 0) {
+        break;
+      }
+    }
+
     buffer = calloc(buffer_size, sizeof(uint8_t));
     uint32_t read_count = 0;
     printf("+OK Write bytecode\r\n");
@@ -195,19 +251,59 @@ int mrbwrite_cmd_mode() {
     }
 
     // 書き込み結果の判定とファイル保存
-    if (read_count == buffer_size) {
-      vfs_write("master.mrbc", buffer, buffer_size);
-      printf("+DONE\r\n");
-    } else {
+    if (read_count != buffer_size) {
       printf("-ERR Timeout while reading bytecode. Expected %d bytes, got %d bytes.\r\n", buffer_size, read_count);
+    } else if (crc >= 0 && mrbwrite_crc16(buffer, buffer_size) != (uint16_t)crc) {
+      printf("-ERR CRC mismatch.\r\n");
+    } else {
+      vfs_write(filename, buffer, buffer_size);
+      printf("+DONE\r\n");
+    }
+    free(buffer);
+  }
+  // ライブラリバイトコード書き込みコマンドの処理
+  if (cmd == MRBWRITE_WRITE_LIB) {
+    // 書き込み先の決定
+    char filename[16];
+    uint32_t size = 0;
+    for (int i = 1; ; i++) {
+      snprintf(filename, sizeof(filename), "lib_%02d.mrbc", i);
+      if (vfs_stat_size(filename, &size) < 0) {
+        break;
+      }
+    }
+
+    buffer = calloc(buffer_size, sizeof(uint8_t));
+    uint32_t read_count = 0;
+    printf("+OK Write bytecode\r\n");
+
+    // バイトコードの連続読み込み
+    for (; read_count < buffer_size; read_count++) {
+      int input = getchar_timeout_us(60 * 1000 * 1000);
+      if (input == PICO_ERROR_TIMEOUT) {
+        break;
+      }
+      buffer[read_count] = (uint8_t)(input & 0xFF);
+    }
+
+    // 書き込み結果の判定とファイル保存
+    if (read_count != buffer_size) {
+      printf("-ERR Timeout while reading bytecode. Expected %d bytes, got %d bytes.\r\n", buffer_size, read_count);
+    } else if (crc >= 0 && mrbwrite_crc16(buffer, buffer_size) != (uint16_t)crc) {
+      printf("-ERR CRC mismatch.\r\n");
+    } else {
+      vfs_write(filename, buffer, buffer_size);
+      printf("+DONE\r\n");
     }
     free(buffer);
   }
   // ファイル消去コマンドの処理
   if (cmd == MRBWRITE_CLEAR) {
-    vfs_remove("master.mrbc");
-    vfs_remove("slave.mrbc");
-    printf("+OK\r\n");
+    if (vfs_format() < 0) {
+      printf("-ERR Format failed.\r\n");
+    } else {
+      printf("+OK\r\n");
+    }
   }
 
   // ヘルプコマンドの処理
@@ -216,6 +312,7 @@ int mrbwrite_cmd_mode() {
     printf("Commands:\r\n");
     printf("  version\r\n");
     printf("  write\r\n");
+    printf("  write_lib\r\n");
     printf("  showprog\r\n");
     printf("  clear\r\n");
     printf("  reset\r\n");
@@ -230,34 +327,40 @@ int mrbwrite_cmd_mode() {
   }
   // プログラム表示コマンドの処理
   if (cmd == MRBWRITE_SHOWPROG) {
-    if (vfs_stat_size("master.mrbc", &buffer_size) >= 0 && buffer_size > 0) {
+    char filename[16];
+    for (int i = 1; ; i++) {
+      snprintf(filename, sizeof(filename), "lib_%02d.mrbc", i);
+      if (vfs_stat_size(filename, &buffer_size) < 0) {
+        break;
+      }
       buffer = calloc(buffer_size, sizeof(uint8_t));
-      if (buffer != NULL && vfs_read("master.mrbc", buffer, buffer_size) > 0) {
-        mrbwrite_showprog("master.mrbc", buffer, buffer_size);
+      if (buffer != NULL && vfs_read(filename, buffer, buffer_size) > 0) {
+        mrbwrite_showprog(filename, buffer, buffer_size);
         free(buffer);
       }
     }
-    if (vfs_stat_size("slave.mrbc", &buffer_size) >= 0 && buffer_size > 0) {
+    for (int i = 1; ; i++) {
+      snprintf(filename, sizeof(filename), "task_%02d.mrbc", i);
+      if (vfs_stat_size(filename, &buffer_size) < 0) {
+        break;
+      }
       buffer = calloc(buffer_size, sizeof(uint8_t));
-      if (buffer != NULL && vfs_read("slave.mrbc", buffer, buffer_size) > 0) {
-        mrbwrite_showprog("slave.mrbc", buffer, buffer_size);
+      if (buffer != NULL && vfs_read(filename, buffer, buffer_size) > 0) {
+        mrbwrite_showprog(filename, buffer, buffer_size);
         free(buffer);
       }
     }
     printf("+DONE\r\n");
   }
 
-  // バイトコード検証コマンドの処理
+  // バイトコード検証コマンドの処理 [DEPRECATED] mrbwrite v1.3で削除
   if (cmd == MRBWRITE_VERIFY) {
-    printf("+OK\r\n");
     uint8_t crc = 0x00;
-    if (vfs_crc8("master.mrbc", &crc) >= 0) {
-      printf("+OK master.mrbc CRC8: %02x\r\n", crc);
+    if (vfs_crc8("task_01.mrbc", &crc) >= 0) {
+      printf("+OK %02x\r\n", crc);
+    } else {
+      printf("-ERR Not task_01.mrbc exists.\r\n");
     }
-    if (vfs_crc8("slave.mrbc", &crc) >= 0) {
-      printf("+OK slave.mrbc CRC8: %02x\r\n", crc);
-    }
-    printf("+DONE\r\n");
   }
   return 1;
 }

--- a/main/mrbwrite.c
+++ b/main/mrbwrite.c
@@ -2,7 +2,7 @@
   @brief mruby/c用のコマンドライン機能
 
   ユーザーからのコマンド入力を受け取り，解析して適切なコマンド番号を返す機能と，
-  バイトコードのヘキサダンプ表示機能を提供する．
+  バイトコードのヘキサダンプ表示，CRC16計算の機能を提供する．
 */
 #include "mrbwrite.h"
 #include "pico/stdlib.h" 
@@ -13,26 +13,29 @@
 /** @brief ユーザー入力のコマンド番号取得
 
   シリアル入力からコマンドを受け取り，対応するコマンド番号を返す．
-  writeコマンドの場合は，サイズパラメータも同時に取得する．
+  write・write_libコマンドの場合は，サイズとCRCパラメータも同時に取得する．
 
   @param timeout_us タイムアウト時間（マイクロ秒）
-  @param size writeコマンドのときに書き込みサイズが設定される．呼び出し側で利用しない場合はNULLを指定可能
+  @param size write・write_libコマンドのときに書き込みサイズが設定される．呼び出し側で利用しない場合はNULLを指定可能
+  @param crc write・write_libコマンドのときにCRC16（16進表記）の指定があれば設定される．未指定時は-1．呼び出し側で利用しない場合はNULLを指定可能
   @return 下記のコマンド番号
       -2: 正しくないコマンド
       -1: タイムアウト
-      0: (CR+LF)  - コマンドモード
-      1: reset    - ソフトウェアリセット
-      2: execute  - mrubyプログラム実行
-      3: write    - mrubyバイトコード書き込み
-      4: clear    - 書き込み済みバイトコードの消去
-      5: help     - コマンド一覧表示（人間用）
-      6: version  - バージョン表示
-      7: showprog - 書き込み済みプログラムサイズ表示（人間用）
-      8: verify   - バイトコード検証
+      0: (CR+LF)   - コマンドモード
+      1: reset     - ソフトウェアリセット
+      2: execute   - mrubyプログラム実行
+      3: write     - タスクのmrubyバイトコード書き込み
+      4: write_lib - ライブラリのmrubyバイトコード書き込み
+      5: clear     - 書き込み済みバイトコードの消去
+      6: help      - コマンド一覧表示（人間用）
+      7: version   - バージョン表示
+      8: showprog  - 書き込み済みプログラムサイズ表示（人間用）
+      9: verify    - バイトコード検証 [DEPRECATED] mrbwrite v1.3で削除
 */
-int mrbwrite_get_cmd (uint32_t timeout_us, uint32_t *size) {
-  const uint32_t buffer_size = 16; // コマンドバッファのサイズ
+int mrbwrite_get_cmd (uint32_t timeout_us, uint32_t *size, int32_t *crc) {
+  const uint32_t buffer_size = 32;
   uint8_t buffer[buffer_size];
+  memset(buffer, 0, buffer_size);
 
   // コマンド入力の受付
   for (int i = 0; i < buffer_size; i++) {
@@ -47,14 +50,31 @@ int mrbwrite_get_cmd (uint32_t timeout_us, uint32_t *size) {
   }
 
   // コマンドを返す
-  uint32_t dummy = 0;
   if (memcmp(buffer, "\r\n", 2) == 0) {
     return MRBWRITE_COMMAND_MODE;
   } else if (memcmp(buffer, "reset\r\n", 7) == 0) {
     return MRBWRITE_RESET;
   } else if (memcmp(buffer, "execute\r\n", 9) == 0) {
     return MRBWRITE_EXECUTE;
-  } else if (sscanf(buffer, "write %d\r\n", (size == NULL ? &dummy : size)) == 1) {
+  } else if (memcmp(buffer, "write_lib ", 10) == 0) {
+    uint32_t arg_size = 0;
+    uint32_t arg_crc = 0;
+    int argc = sscanf(buffer, "write_lib %d %x\r\n", &arg_size, &arg_crc);
+    if (argc < 1) {
+      return MRBWRITE_ILLEGAL;
+    }
+    if (size != NULL) *size = arg_size;
+    if (crc != NULL) *crc = (argc == 2) ? (int32_t)arg_crc : -1;
+    return MRBWRITE_WRITE_LIB;
+  } else if (memcmp(buffer, "write ", 6) == 0) {
+    uint32_t arg_size = 0;
+    uint32_t arg_crc = 0;
+    int argc = sscanf(buffer, "write %d %x\r\n", &arg_size, &arg_crc);
+    if (argc < 1) {
+      return MRBWRITE_ILLEGAL;
+    }
+    if (size != NULL) *size = arg_size;
+    if (crc != NULL) *crc = (argc == 2) ? (int32_t)arg_crc : -1;
     return MRBWRITE_WRITE;
   } else if (memcmp(buffer, "clear\r\n", 7) == 0) {
     return MRBWRITE_CLEAR;
@@ -107,4 +127,33 @@ void mrbwrite_showprog(const char *filename, uint8_t* buffer, uint32_t size) {
     }
     printf(" |\r\n");
   }
+}
+
+/** @brief バイトコードのCRC16計算
+
+  指定されたバッファの内容からCRC16チェックサムを計算する．
+  生成多項式は0x1021の反射表現0x8408を使用し，LSB-firstで計算した値をビット反転して返す．
+
+  @param buffer 計算対象のバイトコード
+  @param size バッファサイズ
+  @return CRC16値
+*/
+uint16_t mrbwrite_crc16(const uint8_t *buffer, uint32_t size) {
+  // CRC16初期値と生成多項式の設定
+  uint16_t crc = 0x0000;
+  const uint16_t poly = 0x8408;
+
+  // CRC16をバイトごとに計算
+  for (uint32_t i = 0; i < size; i++) {
+    crc ^= buffer[i];
+    for (int j = 0; j < 8; j++) {
+      if (crc & 0x0001) {
+        crc = (crc >> 1) ^ poly;
+      } else {
+        crc >>= 1;
+      }
+    }
+  }
+
+  return ~crc;
 }

--- a/main/mrbwrite.h
+++ b/main/mrbwrite.h
@@ -9,18 +9,22 @@ enum mrbwrite_command_t {
   MRBWRITE_COMMAND_MODE = 0, // コマンドモード (CR+LF)
   MRBWRITE_RESET = 1, // ソフトウェアリセット
   MRBWRITE_EXECUTE = 2, // mrubyプログラム実行
-  MRBWRITE_WRITE = 3, // mrubyバイトコード書き込み
-  MRBWRITE_CLEAR = 4, // 書き込み済みバイトコードの消去
-  MRBWRITE_HELP = 5, // コマンド一覧表示（人間用）
-  MRBWRITE_VERSION = 6, // バージョン表示
-  MRBWRITE_SHOWPROG = 7, // 書き込み済みプログラムサイズ表示（人間用）
-  MRBWRITE_VERIFY = 8 // バイトコード検証
+  MRBWRITE_WRITE = 3, // タスクのmrubyバイトコード書き込み
+  MRBWRITE_WRITE_LIB = 4, // ライブラリのmrubyバイトコード書き込み
+  MRBWRITE_CLEAR = 5, // 書き込み済みバイトコードの消去
+  MRBWRITE_HELP = 6, // コマンド一覧表示（人間用）
+  MRBWRITE_VERSION = 7, // バージョン表示
+  MRBWRITE_SHOWPROG = 8, // 書き込み済みプログラムサイズ表示（人間用）
+  MRBWRITE_VERIFY = 9 // バイトコード検証 [DEPRECATED] mrbwrite v1.3で削除
 };
 
-// mrbwrite_get_cmd(timeout_us, size) ユーザー入力のコマンド番号取得
-int mrbwrite_get_cmd(uint32_t timeout_us, uint32_t *size);
+// mrbwrite_get_cmd(timeout_us, size, crc) ユーザー入力のコマンド番号取得
+int mrbwrite_get_cmd(uint32_t timeout_us, uint32_t *size, int32_t *crc);
 
 // バイトコードのヘキサダンプ表示
 void mrbwrite_showprog(const char *filename, uint8_t* buffer, uint32_t size);
+
+// バイトコードのCRC16計算
+uint16_t mrbwrite_crc16(const uint8_t *buffer, uint32_t size);
 
 #endif // MRBWRITE_H

--- a/main/vfs.c
+++ b/main/vfs.c
@@ -206,7 +206,28 @@ int vfs_unmount() {
   return lfs_unmount(&lfs);
 }
 
-/** @brief ファイルのCRC8チェックサム計算
+/** @brief ファイルシステムのリセット
+
+  ファイルシステムを再作成し，保存されているすべてのファイルを消去する．
+  フォーマットの前後でアンマウントとマウントを行う．
+
+  @return 成功時は0，失敗時は負の値を返す
+*/
+int vfs_format() {
+  int ret = lfs_unmount(&lfs);
+  if (ret < 0) {
+    return ret;
+  }
+
+  ret = lfs_format(&lfs, &cfg);
+  if (ret < 0) {
+    return ret;
+  }
+
+  return lfs_mount(&lfs, &cfg);
+}
+
+/** @brief ファイルのCRC8チェックサム計算 [DEPRECATED] mrbwrite v1.3で削除
 
   指定されたファイルの内容からCRC8チェックサムを計算する．
   生成多項式は0x31を使用し，初期値は0xFFとする．

--- a/main/vfs.h
+++ b/main/vfs.h
@@ -24,7 +24,10 @@ int vfs_remove(const char* filename);
 // vfs_unmount() ファイルシステムのアンマウント
 int vfs_unmount(void);
 
-// vfs_crc8(filename, _crc) ファイルのCRC8チェックサム計算
+// vfs_format() ファイルシステムのリセット
+int vfs_format(void);
+
+// vfs_crc8(filename, _crc) ファイルのCRC8チェックサム計算 [DEPRECATED] mrbwrite v1.3で削除
 int vfs_crc8(const char* filename, uint8_t* _crc);
 
 #endif // VFS_H


### PR DESCRIPTION
# 概要
mrbwrite 1.3で変更される可能性がある下記に追随します。

1. `write_lib`コマンドの追加
2. `write`コマンドへのオプション追加
3. `verify`コマンドの非推奨化（1.3正式決定後に削除）

# 詳細

まず、Rubyコードに対する呼び方が変わります。
今までは2つのタスクを並列に実行でき、それらは「master」「slave」と呼ばれていました。
しかし今後は並列プログラムを3つ以上書き込めるようになるため、これらを「タスク／tasks」と呼びます。
（masterは「0番目のタスク」、slaveは「1番目のタスク」に相当します）

また、独自のRubyクラスを使いたい要求に対応します。
master / slaveの2並列程度であればそれぞれのRubyコードの先頭に同じクラス定義をすればよかったのですが、今後の拡張性のため、タスクの実行前にクラス・定数などのライブラリを定義するタイミングを設けることになりました。

これらは「ライブラリ／libraries」と呼ばれ、後述の`write_lib`コマンドで書き込まれます。

## １． `write_lib`コマンドの追加

ライブラリ（ユーザー定義のRubyクラス等）を書き込むコマンドです。
`write`コマンドと同じで、複数回呼ばれると追記されます。
`clear`コマンドでタスクと一緒に削除されます。

タスクは、ライブラリのRubyコード実行終了後に呼ばれます。

## ２． `write`コマンドへのオプション追加

`write`コマンドは必須の引数を1つとり、それは書き込むRubyバイトコードのバイト数です。
今回、任意の第2引数としてCRC-16-LSB（誤り検出符号）を指定できるようにします。
これが指定された場合、`write`および`write_lib`による書き込み後にチェックを行い、誤り検出された場合はエラー `-ERR ...`が返されます。

## ３． `verify`コマンドの非推奨化

`write`および`write_lib`コマンドにCRC引数が追加されたことにより、`verify`コマンドは不要になりました。
現在は互換性のため残していますが、mrbwrite v1.3正式対応時に削除されます。